### PR TITLE
Update dependency declarations to fix fatal exceptions.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,10 @@ description: Example showing how to serve files from asset to Webview.
 dependencies:
   flutter:
     sdk: flutter
-  flutter_webview_plugin: ^0.0.9+1
-  jaguar: ^1.1.5
-  jaguar_flutter_asset: ^1.1.5
-  cupertino_icons: ^0.1.0
+  flutter_webview_plugin: "^0.1.5"
+  jaguar: "^2.0.2"
+  jaguar_flutter_asset: "^1.1.5"
+  cupertino_icons: "^0.1.2"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
pubspec.yaml had some declaration dependencies that didn't require the latest non-breaking version.
 Because flutter now uses dart 2, the belowerror occured. Culprit was the outdated `flutter webview plugin`:
 ```type 'Future<dynamic>' is not a subtype of type 'Future<Null>' where
I/flutter ( 3574):   Future is from dart:async
I/flutter ( 3574):   Future is from dart:async
I/flutter ( 3574):   Null is from dart:core
I/flutter ( 3574): When the exception was thrown, this was the stack:
I/flutter ( 3574): #0      FlutterWebviewPlugin.launch (package:flutter_webview_plugin/flutter_webview_plugin.dart:63:16)
```
After applying this patch, I ran `flutter clean`, `flutter packages upgrade`, `flutter run`. Works now.